### PR TITLE
Add inbox and conversation endpoint

### DIFF
--- a/tap_gladly/schemas/conversation.json
+++ b/tap_gladly/schemas/conversation.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "customerId": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "agentId": {
+      "type": "string"
+    },
+    "inboxId": {
+      "type": "string"
+    },
+    "topicIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "closedAt": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "createdAt",
+    "customerId",
+    "id",
+    "inboxId",
+    "status"
+  ]
+}

--- a/tap_gladly/schemas/export_conversation.json
+++ b/tap_gladly/schemas/export_conversation.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "conversationId": {
+      "type": "string"
+    },
+    "customerId": {
+      "type": "string"
+    },
+    "initiator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "customerId",
+    "id",
+    "timestamp"
+  ]
+}

--- a/tap_gladly/schemas/inbox.json
+++ b/tap_gladly/schemas/inbox.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "disabled": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "disabled",
+    "id",
+    "name"
+  ]
+}

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -8,6 +8,7 @@ import pendulum
 import requests
 from singer_sdk import exceptions
 from singer_sdk.helpers.jsonpath import extract_jsonpath
+from singer_sdk.mapper import RemoveRecordTransform, StreamMap, SameRecordTransform
 
 from tap_gladly.client import gladlyStream
 
@@ -17,7 +18,7 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 class ExportCompletedJobsStream(gladlyStream):
     """List export jobs stream."""
 
-    name = "jobs"
+    name = "export__jobs"
     path = "/export/jobs?status=COMPLETED"
     primary_keys = ["id"]
     replication_key = None
@@ -27,7 +28,7 @@ class ExportCompletedJobsStream(gladlyStream):
     def post_process(self, row, context):
         """Filter jobs that finished before start_date."""
         if pendulum.parse(row["parameters"]["endAt"]) >= pendulum.parse(
-            self.config["start_date"]
+                self.config["start_date"]
         ):
             return row
         return
@@ -40,7 +41,7 @@ class ExportCompletedJobsStream(gladlyStream):
 class ExportFileTopicsStream(gladlyStream):
     """Abstract class, export conversation items stream."""
 
-    name = "topics"
+    name = "export__topics"
     path = "/export/jobs/{job_id}/files/topics.jsonl"
     primary_keys = ["id"]
     replication_key = None
@@ -54,15 +55,34 @@ class ExportFileTopicsStream(gladlyStream):
             yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))
 
 
-class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
-    """Abstract class, export conversation items stream."""
-
-    name = "conversation_conversation_items"
+class ExportFileConversationItemsStream(gladlyStream):
+    name = "export__conversation_conversation_items"
     path = "/export/jobs/{job_id}/files/conversation_items.jsonl"
     primary_keys = ["id"]
     replication_key = None
     parent_stream_type = ExportCompletedJobsStream
     ignore_parent_replication_key = True
+    schema_filepath = SCHEMAS_DIR / "export_conversation.json"
+
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {"conversationId": record.get("conversationId")}
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        """Parse the response and return an iterator of result records."""
+        for line in response.iter_lines():
+            yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+
+        return {"conversationId": record[
+            "conversationId"]} if 'conversationId' in record else record
+
+
+class ExportFileConversationItemsByTypeStream(ExportFileConversationItemsStream,
+                                              abc.ABC):
+    """Abstract class, export conversation items stream."""
 
     @property
     def schema_filepath(self):
@@ -72,9 +92,10 @@ class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
             "conversation_note": "export_conversation-conversation_note.json",
             "topic_change": "export_conversation-topic_change.json",
             "sms": "export_conversation-topic_change.json",
-            "conversation_status_change": "export_conversation-conversation_status_change.json",  # noqa
+            "conversation_status_change": "export_conversation-conversation_status_change.json",
+            # noqa
             "phone_call": "export_conversation-phone_call.json",
-            "voicemail": "export_conversation-voicemail.json",
+            "voicemail": "export_conversation-voicemail.json"
         }
 
         try:
@@ -85,66 +106,92 @@ class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
                 "conversations streams"
             )
 
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        """Parse the response and return an iterator of result records."""
-        for line in response.iter_lines():
-            yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))
-
     def post_process(self, row, context):
         """Filter rows by content type."""
         if row["content"]["type"].lower() == self.content_type.lower():
             return row
 
 
-class ExportFileConversationItemsChatMessage(ExportFileConversationItemsStream):
+class ExportFileConversationItemsChatMessage(ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is chat_message."""
 
-    name = "conversation_chat_message"
+    name = "export__conversation_chat_message"
     content_type = "chat_message"
 
 
-class ExportFileConversationItemsConversationNote(ExportFileConversationItemsStream):
+class ExportFileConversationItemsConversationNote(
+    ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is conversation_note."""
 
-    name = "conversation_conversation_note"
+    name = "export__conversation_conversation_note"
     content_type = "conversation_note"
 
 
-class ExportFileConversationItemsTopicChange(ExportFileConversationItemsStream):
+class ExportFileConversationItemsTopicChange(ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is topic_change."""
 
-    name = "conversation_topic_change"
+    name = "export__conversation_topic_change"
     content_type = "topic_change"
 
 
-class ExportFileConversationItemsSms(ExportFileConversationItemsStream):
+class ExportFileConversationItemsSms(ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is sms."""
 
-    name = "conversation_sms"
+    name = "export__conversation_sms"
     content_type = "sms"
 
 
 class ExportFileConversationItemsConversationStatusChange(
-    ExportFileConversationItemsStream
+    ExportFileConversationItemsByTypeStream
 ):
     """Export conversation items stream.
 
     Where content type is conversation_status_change.
     """
 
-    name = "conversation_conversation_status_change"
+    name = "export__conversation_conversation_status_change"
     content_type = "conversation_status_change"
 
 
-class ExportFileConversationItemsPhoneCall(ExportFileConversationItemsStream):
+class ExportFileConversationItemsPhoneCall(ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is phone_call."""
 
-    name = "conversation_phone_call"
+    name = "export__conversation_phone_call"
     content_type = "phone_call"
 
 
-class ExportFileConversationItemsVoiceMail(ExportFileConversationItemsStream):
+class ExportFileConversationItemsVoiceMail(ExportFileConversationItemsByTypeStream):
     """Export conversation items stream where content type is voicemail."""
 
-    name = "conversation_voicemail"
+    name = "export__conversation_voicemail"
     content_type = "voicemail"
+
+
+class ConversationStream(gladlyStream):
+    """Get Conversations."""
+
+    name = "conversation"
+    path = "/conversations/{conversationId}"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "conversation.json"
+    parent_stream_type = ExportFileConversationItemsStream
+    ignore_parent_replication_key = True
+
+    def get_records(self, context: dict):
+        if 'conversationId' not in context:
+            return []
+        return super().get_records(context)
+
+
+class InboxStream(gladlyStream):
+    """Export Inboxes."""
+
+    name = "inbox"
+    path = "/inboxes"
+    primary_keys = ["id"]
+    schema_filepath = SCHEMAS_DIR / "inbox.json"
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        """Parse the response and return an iterator of result records."""
+        for line in response.iter_lines():
+            yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))

--- a/tap_gladly/tap.py
+++ b/tap_gladly/tap.py
@@ -16,10 +16,14 @@ from tap_gladly.streams import (
     ExportFileConversationItemsTopicChange,
     ExportFileConversationItemsVoiceMail,
     ExportFileTopicsStream,
+    InboxStream,
+    ConversationStream, ExportFileConversationItemsStream
 )
 
 STREAM_TYPES = [
+    ConversationStream,
     ExportCompletedJobsStream,
+    ExportFileConversationItemsStream,
     ExportFileConversationItemsChatMessage,
     ExportFileConversationItemsConversationNote,
     ExportFileConversationItemsTopicChange,
@@ -28,6 +32,7 @@ STREAM_TYPES = [
     ExportFileConversationItemsPhoneCall,
     ExportFileConversationItemsVoiceMail,
     ExportFileTopicsStream,
+    InboxStream
 ]
 
 
@@ -36,7 +41,6 @@ class Tapgladly(Tap):
 
     name = "tap-gladly"
 
-    # TODO: Update this section with the actual config values you expect:
     config_jsonschema = th.PropertiesList(
         th.Property(
             "username",


### PR DESCRIPTION
## Description

The only way to get inbox data to have use the GET conversation API, which has an inbox field. This PR lookup all the conversation we get from the export with that endpoint and adds an inbox stream. Since inbox is not an event table and is small, we don't filter with start date.