### PR TITLE
Add email stream and correct schema based on Gladly API

### DIFF
--- a/tap_gladly/schemas/export_conversation-chat_message.json
+++ b/tap_gladly/schemas/export_conversation-chat_message.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-conversation_note.json
+++ b/tap_gladly/schemas/export_conversation-conversation_note.json
@@ -36,6 +36,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-conversation_status_change.json
+++ b/tap_gladly/schemas/export_conversation-conversation_status_change.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-customer_activity.json
+++ b/tap_gladly/schemas/export_conversation-customer_activity.json
@@ -64,11 +64,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-email.json
+++ b/tap_gladly/schemas/export_conversation-email.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "conversationId": {
+      "type": "string"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "cc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bcc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "from",
+        "to",
+        "type",
+        "subject"
+      ]
+    },
+    "customerId": {
+      "type": "string"
+    },
+    "initiator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+      },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "content",
+    "customerId",
+    "id",
+    "timestamp"
+  ]
+}

--- a/tap_gladly/schemas/export_conversation-facebook_message.json
+++ b/tap_gladly/schemas/export_conversation-facebook_message.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-instagram_direct.json
+++ b/tap_gladly/schemas/export_conversation-instagram_direct.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-sms.json
+++ b/tap_gladly/schemas/export_conversation-sms.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-topic_change.json
+++ b/tap_gladly/schemas/export_conversation-topic_change.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-twitter.json
+++ b/tap_gladly/schemas/export_conversation-twitter.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-voicemail.json
+++ b/tap_gladly/schemas/export_conversation-voicemail.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-whatsapp.json
+++ b/tap_gladly/schemas/export_conversation-whatsapp.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -84,6 +84,7 @@ class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
             "twitter": "export_conversation-twitter.json",
             "instagram_direct": "export_conversation-instagram_direct.json",
             "whatsapp": "export_conversation-whatsapp.json",
+            "email": "export_conversation-email.json",
         }
 
         try:
@@ -192,6 +193,13 @@ class ExportFileConversationItemsWhatsapp(ExportFileConversationItemsStream):
 
     name = "conversation_whatsapp"
     content_type = "whatsapp"
+
+
+class ExportFileConversationItemsEmail(ExportFileConversationItemsStream):
+    """Export conversation items stream where content type is voicemail."""
+
+    name = "conversation_email"
+    content_type = "email"
 
 
 class ReportsConversationTimestampsReportStream(gladlyStream):

--- a/tap_gladly/tap.py
+++ b/tap_gladly/tap.py
@@ -12,6 +12,7 @@ from tap_gladly.streams import (
     ExportFileConversationItemsConversationNote,
     ExportFileConversationItemsConversationStatusChange,
     ExportFileConversationItemsCustomerActivity,
+    ExportFileConversationItemsEmail,
     ExportFileConversationItemsFacebookMessage,
     ExportFileConversationItemsInstagramDirect,
     ExportFileConversationItemsPhoneCall,
@@ -39,6 +40,7 @@ STREAM_TYPES = [
     ExportFileConversationItemsTwitter,
     ExportFileConversationItemsInstagramDirect,
     ExportFileConversationItemsWhatsapp,
+    ExportFileConversationItemsEmail,
     ReportsConversationTimestampsReportStream,
 ]
 


### PR DESCRIPTION
## Description

* Adding Email stream (content__type == 'EMAIL').
* Adding the responder ID to table.

## Test

```
$ tap-gladly > output.jsonl
$ cat output.jsonl | jq '. | select( .stream=="conversation_email")' | wc -l
  240381
```