### PR TITLE
Add stream with all the conversations and email stream

### DIFF
--- a/tap_gladly/schemas/export_conversation-all_types.json
+++ b/tap_gladly/schemas/export_conversation-all_types.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "customerId": {
+      "type": "string"
+    },
+    "conversationId": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "initiator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    }
+  },
+  "required": [
+    "content",
+    "customerId",
+    "id",
+    "timestamp"
+  ]
+}

--- a/tap_gladly/schemas/export_conversation-chat_message.json
+++ b/tap_gladly/schemas/export_conversation-chat_message.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-conversation_note.json
+++ b/tap_gladly/schemas/export_conversation-conversation_note.json
@@ -36,6 +36,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-conversation_status_change.json
+++ b/tap_gladly/schemas/export_conversation-conversation_status_change.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-customer_activity.json
+++ b/tap_gladly/schemas/export_conversation-customer_activity.json
@@ -64,11 +64,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-email.json
+++ b/tap_gladly/schemas/export_conversation-email.json
@@ -46,8 +46,7 @@
         "content",
         "from",
         "to",
-        "type",
-        "subject"
+        "type"
       ]
     },
     "customerId": {

--- a/tap_gladly/schemas/export_conversation-email.json
+++ b/tap_gladly/schemas/export_conversation-email.json
@@ -11,16 +11,43 @@
     "content": {
       "type": "object",
       "properties": {
+        "to": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        },
         "content": {
           "type": "string"
         },
         "type": {
           "type": "string"
+        },
+        "cc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bcc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "content",
-        "type"
+        "from",
+        "to",
+        "type",
+        "subject"
       ]
     },
     "customerId": {
@@ -36,7 +63,7 @@
           "type": "string"
         }
       }
-    },
+      },
     "responder": {
       "type": "object",
       "properties": {

--- a/tap_gladly/schemas/export_conversation-facebook_message.json
+++ b/tap_gladly/schemas/export_conversation-facebook_message.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-sms.json
+++ b/tap_gladly/schemas/export_conversation-sms.json
@@ -43,11 +43,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-topic_change.json
+++ b/tap_gladly/schemas/export_conversation-topic_change.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-twitter.json
+++ b/tap_gladly/schemas/export_conversation-twitter.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/schemas/export_conversation-voicemail.json
+++ b/tap_gladly/schemas/export_conversation-voicemail.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
     "timestamp": {
       "type": "string"
     }

--- a/tap_gladly/schemas/export_conversation-whatsapp.json
+++ b/tap_gladly/schemas/export_conversation-whatsapp.json
@@ -35,11 +35,18 @@
         "id": {
           "type": "string"
         }
-      },
-      "required": [
-        "id",
-        "type"
-      ]
+      }
+    },
+    "responder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "timestamp": {
       "type": "string"

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -58,6 +58,25 @@ class ExportFileTopicsStream(gladlyStream):
             yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))
 
 
+class ExportFileConversationItemsAllTypesStream(gladlyStream):
+    """Stream with all the conversations and content type."""
+
+    name = "conversation_all_types"
+    path = "/export/jobs/{job_id}/files/conversation_items.jsonl"
+    primary_keys = ["id"]
+    replication_key = None
+    parent_stream_type = ExportCompletedJobsStream
+    ignore_parent_replication_key = True
+    schema_filepath = SCHEMAS_DIR / "export_conversation-all_types.json"
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        """Parse the response and return an iterator of result records."""
+        for line in response.iter_lines():
+            record = json.loads(line)
+            record["content"] = {"type": record["content"]["type"]}
+            yield from extract_jsonpath(self.records_jsonpath, input=record)
+
+
 class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
     """Abstract class, export conversation items stream."""
 

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -103,6 +103,7 @@ class ExportFileConversationItemsStream(gladlyStream, abc.ABC):
             "twitter": "export_conversation-twitter.json",
             "instagram_direct": "export_conversation-instagram_direct.json",
             "whatsapp": "export_conversation-whatsapp.json",
+            "email": "export_conversation-email.json",
         }
 
         try:
@@ -211,6 +212,13 @@ class ExportFileConversationItemsWhatsapp(ExportFileConversationItemsStream):
 
     name = "conversation_whatsapp"
     content_type = "whatsapp"
+
+
+class ExportFileConversationItemsEmail(ExportFileConversationItemsStream):
+    """Export conversation items stream where content type is voicemail."""
+
+    name = "conversation_email"
+    content_type = "email"
 
 
 class ReportsConversationTimestampsReportStream(gladlyStream):

--- a/tap_gladly/tap.py
+++ b/tap_gladly/tap.py
@@ -13,6 +13,7 @@ from tap_gladly.streams import (
     ExportFileConversationItemsConversationNote,
     ExportFileConversationItemsConversationStatusChange,
     ExportFileConversationItemsCustomerActivity,
+    ExportFileConversationItemsEmail,
     ExportFileConversationItemsFacebookMessage,
     ExportFileConversationItemsInstagramDirect,
     ExportFileConversationItemsPhoneCall,
@@ -40,6 +41,7 @@ STREAM_TYPES = [
     ExportFileConversationItemsTwitter,
     ExportFileConversationItemsInstagramDirect,
     ExportFileConversationItemsWhatsapp,
+    ExportFileConversationItemsEmail,
     ReportsConversationTimestampsReportStream,
     ExportFileConversationItemsAllTypesStream,
 ]

--- a/tap_gladly/tap.py
+++ b/tap_gladly/tap.py
@@ -8,6 +8,7 @@ from singer_sdk import typing as th  # JSON schema typing helpers
 # TODO: Import your custom stream types here:
 from tap_gladly.streams import (
     ExportCompletedJobsStream,
+    ExportFileConversationItemsAllTypesStream,
     ExportFileConversationItemsChatMessage,
     ExportFileConversationItemsConversationNote,
     ExportFileConversationItemsConversationStatusChange,
@@ -40,6 +41,7 @@ STREAM_TYPES = [
     ExportFileConversationItemsInstagramDirect,
     ExportFileConversationItemsWhatsapp,
     ReportsConversationTimestampsReportStream,
+    ExportFileConversationItemsAllTypesStream,
 ]
 
 


### PR DESCRIPTION
# Description

* Add stream to extract all the conversations content type without putting them into different stream, but only keeps `content.type` to differentiate between channels.
* Adding Email stream (content__type == 'EMAIL').
* Adding the responder ID to the other tables.

# QA


```
$ tap-gladly > output.jsonl
$ cat output.jsonl | jq '. | select( .stream=="conversation_email")' | wc -l
  240381
```