### PR TITLE
Bug fix: Subclass out of ExportFile abstract class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-gladly"
-version = "0.4.0"
+version = "0.4.1"
 description = "`tap-gladly` is a Singer tap for gladly, built with the Meltano SDK for Singer Taps."
 authors = ["harrystech"]
 keywords = [

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -48,12 +48,17 @@ class ExportFile(gladlyStream, abc.ABC):
     def get_records(self, context: Optional[Dict[Any, Any]]):
         """Get records that exists, ignoring older jobs if max_job_lookback is setup."""
         if not context:
+            logging.warning("Context is empty, nothing to do")
             return []
         period = pendulum.now().diff(pendulum.parse(context["updatedAt"])).in_days()
         if "max_job_lookback" in self.config:
-            logging.info(f"Max job lookback is set to {self.config['max_job_lookback']}")
+            logging.info(
+                f"Max job lookback is set to {self.config['max_job_lookback']}"
+            )
             if period <= self.config["max_job_lookback"]:
-                logging.info(f"{period} <= {self.config['max_job_lookback']}, syncing ...")
+                logging.info(
+                    f"{period} <= {self.config['max_job_lookback']}, syncing ..."
+                )
                 return super().get_records(context)
             else:
                 logging.warning(
@@ -82,7 +87,7 @@ class ExportFileTopicsStream(ExportFile):
             yield from extract_jsonpath(self.records_jsonpath, input=json.loads(line))
 
 
-class ExportFileConversationItemsAllTypesStream(gladlyStream):
+class ExportFileConversationItemsAllTypesStream(ExportFile):
     """Stream with all the conversations and content type."""
 
     name = "conversation_all_types"

--- a/tap_gladly/streams.py
+++ b/tap_gladly/streams.py
@@ -51,7 +51,9 @@ class ExportFile(gladlyStream, abc.ABC):
             return []
         period = pendulum.now().diff(pendulum.parse(context["updatedAt"])).in_days()
         if "max_job_lookback" in self.config:
+            logging.info(f"Max job lookback is set to {self.config['max_job_lookback']}")
             if period <= self.config["max_job_lookback"]:
+                logging.info(f"{period} <= {self.config['max_job_lookback']}, syncing ...")
                 return super().get_records(context)
             else:
                 logging.warning(


### PR DESCRIPTION
## Description

A class was using the wrong parent class, which lead it to not apply correctly the logic around `max_job_lookback`.

## QA

Extractor succeeding in Airflow on an old data interval:

![image](https://user-images.githubusercontent.com/109112933/198403402-6b8a901b-24ee-48b8-a7b8-e833c8091af7.png)
